### PR TITLE
removed redundant line of code

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -271,7 +271,6 @@ class App extends Component {
 							if (meeting.postal_code) temp = temp + " " + meeting.postal_code;
 							if (meeting.country) temp = temp + ", " + meeting.country;
 							meeting.formatted_address = temp;
-							result[i].formatted_address = meeting.formatted_address;
 						} else {
 							console.error('Formatted address could not be created, at least address and city required.');
 						}


### PR DESCRIPTION
In building this functionality into the booklet-generator project I realized that because Javascript objects are assigned by reference that line 273 does update the value of result[I] so line 274 was thus redundant.

This is a super miniscule thing to change, but since I noticed it I figured I'd do a pull request.